### PR TITLE
[Release] Version 0.0.3

### DIFF
--- a/TwitchLib.EventSub.Websockets/TwitchLib.EventSub.Websockets.csproj
+++ b/TwitchLib.EventSub.Websockets/TwitchLib.EventSub.Websockets.csproj
@@ -5,10 +5,10 @@
 	<PackageId>TwitchLib.EventSub.Websockets</PackageId>
     <Title>TwitchLib.EventSub.Websockets</Title>
 	<Authors>swiftyspiffy, Prom3theu5, Syzuna, LuckyNoS7evin</Authors>
-	<VersionPrefix>0.0.2</VersionPrefix>
+	<VersionPrefix>0.0.3</VersionPrefix>
 	<VersionSuffix>$(VersionSuffix)</VersionSuffix>
-	<AssemblyVersion>0.0.2</AssemblyVersion>
-	<FileVersion>0.0.2</FileVersion>
+	<AssemblyVersion>0.0.3</AssemblyVersion>
+	<FileVersion>0.0.3</FileVersion>
 	<Description>EventSub Websockets (also known as EventSockets) Client Library</Description>
 	<PackageIconUrl>https://cdn.syzuna-programs.de/images/twitchlib.png</PackageIconUrl>
 	<PackageProjectUrl>https://github.com/TwitchLib/TwitchLib.EventSub.Websockets</PackageProjectUrl>


### PR DESCRIPTION
Changelog:
- Added .NET Standard 2.0 and 2.1 support.
( Because of this, the library can now be used from .NET Framwork 4.6.2 and up)
- Added example that uses the .NET Standard 2.0 version in a .NET Framework 4.8 project