### PR TITLE
Added support for subscription type channel.ad_break.begin

### DIFF
--- a/TwitchLib.EventSub.Websockets/Core/EventArgs/Channel/ChannelAdBreakBeginArgs.cs
+++ b/TwitchLib.EventSub.Websockets/Core/EventArgs/Channel/ChannelAdBreakBeginArgs.cs
@@ -1,0 +1,8 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+using TwitchLib.EventSub.Websockets.Core.Models;
+namespace TwitchLib.EventSub.Websockets.Core.EventArgs.Channel
+{
+    public class ChannelAdBreakBeginArgs : TwitchLibEventSubEventArgs<EventSubNotification<ChannelAdBreakBegin>>
+    {
+    }
+}

--- a/TwitchLib.EventSub.Websockets/EventSubWebsocketClient.cs
+++ b/TwitchLib.EventSub.Websockets/EventSubWebsocketClient.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,15 +8,14 @@ using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging.Abstractions;
+using TwitchLib.EventSub.Core;
+using TwitchLib.EventSub.Core.Extensions;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
 using TwitchLib.EventSub.Websockets.Client;
 using TwitchLib.EventSub.Websockets.Core.EventArgs;
 using TwitchLib.EventSub.Websockets.Core.EventArgs.Channel;
 using TwitchLib.EventSub.Websockets.Core.EventArgs.Stream;
 using TwitchLib.EventSub.Websockets.Core.EventArgs.User;
-using TwitchLib.EventSub.Core;
-using TwitchLib.EventSub.Core.Extensions;
-using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
 using TwitchLib.EventSub.Websockets.Core.Handler;
 using TwitchLib.EventSub.Websockets.Core.Models;
 using TwitchLib.EventSub.Websockets.Core.NamingPolicies;
@@ -45,6 +45,11 @@ namespace TwitchLib.EventSub.Websockets
         /// Event that triggers when the websocket was successfully reconnected
         /// </summary>
         public event AsyncEventHandler WebsocketReconnected;
+
+        /// <summary>
+        /// Event that triggers on "channel.ad_break.begin" notifications
+        /// </summary>
+        public event AsyncEventHandler<ChannelAdBreakBeginArgs> ChannelAdBreakBegin;
 
         /// <summary>
         /// Event that triggers on "channel.ban" notifications
@@ -89,7 +94,7 @@ namespace TwitchLib.EventSub.Websockets
         /// Event that triggers on "channel.goal.progress" notifications
         /// </summary>
         public event AsyncEventHandler<ChannelGoalProgressArgs> ChannelGoalProgress;
-        
+
         /// <summary>
         /// Event that triggers on "channel.guest_star_guest.update" notifications
         /// </summary>
@@ -189,7 +194,7 @@ namespace TwitchLib.EventSub.Websockets
         /// Event that triggers on "channel.raid" notifications
         /// </summary>
         public event AsyncEventHandler<ChannelRaidArgs> ChannelRaid;
-        
+
         /// <summary>
         /// Event that triggers on "channel.shield_mode.begin" notifications
         /// </summary>
@@ -198,7 +203,7 @@ namespace TwitchLib.EventSub.Websockets
         /// Event that triggers on "channel.shield_mode.end" notifications
         /// </summary>
         public event AsyncEventHandler<ChannelShieldModeEndArgs> ChannelShieldModeEnd;
-        
+
         /// <summary>
         /// Event that triggers on "channel.shoutout.create" notifications
         /// </summary>
@@ -310,18 +315,18 @@ namespace TwitchLib.EventSub.Websockets
         public EventSubWebsocketClient(ILoggerFactory loggerFactory = null)
         {
             _loggerFactory = loggerFactory;
-            
-            _logger = _loggerFactory != null 
-                ? _loggerFactory.CreateLogger<EventSubWebsocketClient>() 
+
+            _logger = _loggerFactory != null
+                ? _loggerFactory.CreateLogger<EventSubWebsocketClient>()
                 : NullLogger<EventSubWebsocketClient>.Instance;
 
-            _websocketClient = _loggerFactory != null 
+            _websocketClient = _loggerFactory != null
                 ? new WebsocketClient(_loggerFactory.CreateLogger<WebsocketClient>())
                 : new WebsocketClient();
-            
+
             _websocketClient.OnDataReceived += OnDataReceived;
             _websocketClient.OnErrorOccurred += OnErrorOccurred;
-            
+
             var handlers = typeof(INotificationHandler)
                 .Assembly.ExportedTypes
                 .Where(x => typeof(INotificationHandler).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract)
@@ -329,11 +334,11 @@ namespace TwitchLib.EventSub.Websockets
                 .ToList();
 
             PrepareHandlers(handlers);
-            
+
             _reconnectComplete = false;
             _reconnectRequested = false;
         }
-        
+
         /// <summary>
         /// Connect to Twitch EventSub Websockets
         /// </summary>

--- a/TwitchLib.EventSub.Websockets/Handler/Channel/Ads/AdBreakBeginHandler.cs
+++ b/TwitchLib.EventSub.Websockets/Handler/Channel/Ads/AdBreakBeginHandler.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.Json;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+using TwitchLib.EventSub.Websockets.Core.EventArgs;
+using TwitchLib.EventSub.Websockets.Core.EventArgs.Channel;
+using TwitchLib.EventSub.Websockets.Core.Handler;
+using TwitchLib.EventSub.Websockets.Core.Models;
+
+namespace TwitchLib.EventSub.Websockets.Handler.Channel.Ads
+{
+    /// <summary>
+    /// Handler for 'channel.ad_break.begin' notifications
+    /// </summary>
+    public class AdBreakBeginHandler : INotificationHandler
+    {
+        /// <inheritdoc />
+        public string SubscriptionType => "channel.ad_break.begin";
+
+        /// <inheritdoc />
+        public void Handle(EventSubWebsocketClient client, string jsonString, JsonSerializerOptions serializerOptions)
+        {
+            try
+            {
+                var data = JsonSerializer.Deserialize<EventSubNotification<ChannelAdBreakBegin>>(jsonString.AsSpan(), serializerOptions);
+                if (data is null)
+                    throw new InvalidOperationException("Parsed JSON cannot be null!");
+                client.RaiseEvent("ChannelAdBreakBegin", new ChannelPointsCustomRewardArgs { Notification = data });
+            }
+            catch (Exception ex)
+            {
+                client.RaiseEvent("ErrorOccurred", new ErrorOccuredArgs { Exception = ex, Message = $"Error encountered while trying to handle {SubscriptionType} notification! Raw Json: {jsonString}" });
+            }
+        }
+    }
+}

--- a/TwitchLib.EventSub.Websockets/Handler/Channel/Ads/AdBreakBeginHandler.cs
+++ b/TwitchLib.EventSub.Websockets/Handler/Channel/Ads/AdBreakBeginHandler.cs
@@ -24,7 +24,7 @@ namespace TwitchLib.EventSub.Websockets.Handler.Channel.Ads
                 var data = JsonSerializer.Deserialize<EventSubNotification<ChannelAdBreakBegin>>(jsonString.AsSpan(), serializerOptions);
                 if (data is null)
                     throw new InvalidOperationException("Parsed JSON cannot be null!");
-                client.RaiseEvent("ChannelAdBreakBegin", new ChannelPointsCustomRewardArgs { Notification = data });
+                client.RaiseEvent("ChannelAdBreakBegin", new ChannelAdBreakBeginArgs { Notification = data });
             }
             catch (Exception ex)
             {

--- a/TwitchLib.EventSub.Websockets/TwitchLib.EventSub.Websockets.csproj
+++ b/TwitchLib.EventSub.Websockets/TwitchLib.EventSub.Websockets.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="TwitchLib.EventSub.Core" Version="2.4.3" />
+    <PackageReference Include="TwitchLib.EventSub.Core" Version="2.5.1" />
 	<PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
I believe I did this correctly. Adding support for the EventSub channel.ad_break.begin type. Also updated the dependency for TwitchLib.EventSub.Core to version 2.5.1 to get latest models

What I am not sure is the property LengthSeconds on ChannelAdBreakBegin that is in TwitchLib.EventSub.Core.SubscriptionTypes.Channel if I need to do another PR for that since the API says LengthSeconds should instead be DurationSeconds? If so I can open another PR for that as well