### PR TITLE
Added ChannelModerate

### DIFF
--- a/TwitchLib.EventSub.Websockets/Core/EventArgs/Channel/ChannelModerateArgs.cs
+++ b/TwitchLib.EventSub.Websockets/Core/EventArgs/Channel/ChannelModerateArgs.cs
@@ -1,0 +1,12 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+using TwitchLib.EventSub.Websockets.Core.Models;
+
+namespace TwitchLib.EventSub.Websockets.Core.EventArgs.Channel;
+
+/// <summary>
+/// <see href="https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelmoderate-v2">Twitch Documentation</see><br/>
+/// When a moderator performs a moderation action in a channel.<br/>
+/// Required Scopes: Check documenation for full list<br/>
+/// </summary>
+public class ChannelModerateArgs : TwitchLibEventSubEventArgs<EventSubNotification<ChannelModerate>>
+{ }

--- a/TwitchLib.EventSub.Websockets/EventSubWebsocketClient.cs
+++ b/TwitchLib.EventSub.Websockets/EventSubWebsocketClient.cs
@@ -132,10 +132,14 @@ namespace TwitchLib.EventSub.Websockets
         /// </summary>
         public event AsyncEventHandler<ChannelHypeTrainProgressArgs> ChannelHypeTrainProgress;
 
-        /// <summary>
-        /// Event that triggers on "channel.moderator.add" notifications
-        /// </summary>
-        public event AsyncEventHandler<ChannelModeratorArgs> ChannelModeratorAdd;
+				/// <summary>
+				/// Event that triggers on "channel.moderate" notifications
+				/// </summary>
+				public event AsyncEventHandler<ChannelModerateArgs> ChannelModerate;
+				/// <summary>
+				/// Event that triggers on "channel.moderator.add" notifications
+				/// </summary>
+				public event AsyncEventHandler<ChannelModeratorArgs> ChannelModeratorAdd;
         /// <summary>
         /// Event that triggers on "channel.moderator.remove" notifications
         /// </summary>

--- a/TwitchLib.EventSub.Websockets/Handler/Channel/Moderation/ChannelModerateHandler.cs
+++ b/TwitchLib.EventSub.Websockets/Handler/Channel/Moderation/ChannelModerateHandler.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Text.Json;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+using TwitchLib.EventSub.Websockets.Core.EventArgs;
+using TwitchLib.EventSub.Websockets.Core.EventArgs.Channel;
+using TwitchLib.EventSub.Websockets.Core.Handler;
+using TwitchLib.EventSub.Websockets.Core.Models;
+
+namespace TwitchLib.EventSub.Websockets.Handler.Channel.Moderation;
+
+/// <summary>
+/// Handler for 'channel.moderate' notifications
+/// </summary>
+public class ChannelModerateHandler : INotificationHandler
+{
+	/// <inheritdoc />
+	public string SubscriptionType => "channel.moderate";
+
+	/// <inheritdoc />
+	public void Handle(EventSubWebsocketClient client, string jsonString, JsonSerializerOptions serializerOptions)
+	{
+		try
+		{
+			var data = JsonSerializer.Deserialize<EventSubNotification<ChannelModerate>>(jsonString.AsSpan(), serializerOptions);
+
+			if (data is null)
+				throw new InvalidOperationException("Parsed JSON cannot be null!");
+
+			client.RaiseEvent("ChannelModerate", new ChannelModerateArgs { Notification = data });
+		}
+		catch (Exception ex)
+		{
+			client.RaiseEvent("ErrorOccurred", new ErrorOccuredArgs { Exception = ex, Message = $"Error encountered while trying to handle {SubscriptionType} notification! Raw Json: {jsonString}" });
+		}
+	}
+}


### PR DESCRIPTION
Added Channel Moderate: [Twitch Api Docs](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelmoderate-v2)

Created the Handler, Args, and added the EventHandler to the Websocket Client.
Not sure if I missed anything, just used another class as a template

Models for needed for this was done in this pull request: https://github.com/TwitchLib/TwitchLib.EventSub.Core/pull/31