### PR TITLE
Add support for ChannelChatMessageDelete and ChannelChatNotification

### DIFF
--- a/TwitchLib.EventSub.Websockets/Core/EventArgs/Channel/ChannelChatMessageDeleteArgs.cs
+++ b/TwitchLib.EventSub.Websockets/Core/EventArgs/Channel/ChannelChatMessageDeleteArgs.cs
@@ -1,0 +1,8 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+using TwitchLib.EventSub.Websockets.Core.Models;
+namespace TwitchLib.EventSub.Websockets.Core.EventArgs.Channel
+{
+    public class ChannelChatMessageDeleteArgs : TwitchLibEventSubEventArgs<EventSubNotification<ChannelChatMessageDelete>>
+    {
+    }
+}

--- a/TwitchLib.EventSub.Websockets/Core/EventArgs/Channel/ChannelChatNotificationArgs.cs
+++ b/TwitchLib.EventSub.Websockets/Core/EventArgs/Channel/ChannelChatNotificationArgs.cs
@@ -1,0 +1,8 @@
+﻿using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+using TwitchLib.EventSub.Websockets.Core.Models;
+namespace TwitchLib.EventSub.Websockets.Core.EventArgs.Channel
+{
+    public class ChannelChatNotificationArgs : TwitchLibEventSubEventArgs<EventSubNotification<ChannelChatNotification>>
+    {
+    }
+}

--- a/TwitchLib.EventSub.Websockets/EventSubWebsocketClient.cs
+++ b/TwitchLib.EventSub.Websockets/EventSubWebsocketClient.cs
@@ -77,6 +77,10 @@ namespace TwitchLib.EventSub.Websockets
         /// </summary>
         public event AsyncEventHandler<ChannelChatMessageArgs> ChannelChatMessage;
         /// <summary>
+        /// Event that triggers on "channel.chat.message_delete" notifications
+        /// </summary>
+        public event AsyncEventHandler<ChannelChatMessageDeleteArgs> ChannelChatMessageDelete;
+        /// <summary>
         /// Event that triggers on "channel.cheer" notifications
         /// </summary>
         public event AsyncEventHandler<ChannelCheerArgs> ChannelCheer;

--- a/TwitchLib.EventSub.Websockets/EventSubWebsocketClient.cs
+++ b/TwitchLib.EventSub.Websockets/EventSubWebsocketClient.cs
@@ -81,6 +81,10 @@ namespace TwitchLib.EventSub.Websockets
         /// </summary>
         public event AsyncEventHandler<ChannelChatMessageDeleteArgs> ChannelChatMessageDelete;
         /// <summary>
+        /// Event that triggers on "channel.chat.notification" notifications
+        /// </summary>
+        public event AsyncEventHandler<ChannelChatNotificationArgs> ChannelChatNotification;
+        /// <summary>
         /// Event that triggers on "channel.cheer" notifications
         /// </summary>
         public event AsyncEventHandler<ChannelCheerArgs> ChannelCheer;

--- a/TwitchLib.EventSub.Websockets/Handler/Channel/Chat/ChatMessageDeleteHandler.cs
+++ b/TwitchLib.EventSub.Websockets/Handler/Channel/Chat/ChatMessageDeleteHandler.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Text.Json;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+using TwitchLib.EventSub.Websockets.Core.EventArgs;
+using TwitchLib.EventSub.Websockets.Core.EventArgs.Channel;
+using TwitchLib.EventSub.Websockets.Core.Handler;
+using TwitchLib.EventSub.Websockets.Core.Models;
+
+namespace TwitchLib.EventSub.Websockets.Handler.Channel.Chat
+{
+    public class ChatMessageDeleteHandler : INotificationHandler
+    {
+        public string SubscriptionType => "channel.chat.message_delete";
+
+        public void Handle ( EventSubWebsocketClient client, string jsonString, JsonSerializerOptions serializerOptions )
+        {
+            try
+            {
+                var data = JsonSerializer.Deserialize<EventSubNotification<ChannelChatMessageDelete>>(jsonString.AsSpan(), serializerOptions);
+                if (data is null)
+                    throw new InvalidOperationException("Parsed JSON cannot be null!");
+                client.RaiseEvent("ChannelChatMessageDelete", new ChannelChatMessageDeleteArgs { Notification = data });
+            }
+            catch (Exception ex)
+            {
+                client.RaiseEvent("ErrorOccurred", new ErrorOccuredArgs { Exception = ex, Message = $"Error encountered while trying to handle {SubscriptionType} notification! Raw Json: {jsonString}" });
+            }
+        }
+    }
+}

--- a/TwitchLib.EventSub.Websockets/Handler/Channel/Chat/ChatNotificationHandler.cs
+++ b/TwitchLib.EventSub.Websockets/Handler/Channel/Chat/ChatNotificationHandler.cs
@@ -8,18 +8,18 @@ using TwitchLib.EventSub.Websockets.Core.Models;
 
 namespace TwitchLib.EventSub.Websockets.Handler.Channel.Chat
 {
-    public class ChatMessageDeleteHandler : INotificationHandler
+    public class ChatNotificationHandler : INotificationHandler
     {
-        public string SubscriptionType => "channel.chat.message_delete";
+        public string SubscriptionType => "channel.chat.notification";
 
         public void Handle(EventSubWebsocketClient client, string jsonString, JsonSerializerOptions serializerOptions)
         {
             try
             {
-                var data = JsonSerializer.Deserialize<EventSubNotification<ChannelChatMessageDelete>>(jsonString.AsSpan(), serializerOptions);
+                var data = JsonSerializer.Deserialize<EventSubNotification<ChannelChatNotification>>(jsonString.AsSpan(), serializerOptions);
                 if (data is null)
                     throw new InvalidOperationException("Parsed JSON cannot be null!");
-                client.RaiseEvent("ChannelChatMessageDelete", new ChannelChatMessageDeleteArgs { Notification = data });
+                client.RaiseEvent("ChannelChatNotification", new ChannelChatNotificationArgs { Notification = data });
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Addressing #50 

Added EventHandler, args and events to client. Models were already in core as mentioned.

Also added namespace `TwitchLib.EventSub.Websockets.Handler.Channel.Chat` seeing as there are other namespaces for the other events and a few more chat events still to be implemented.
The only other  "Chat" event was [ChatMessageHandler.cs](https://github.com/TwitchLib/TwitchLib.EventSub.Websockets/blob/6f4cd77bc432fcee430d6f5f536027a99c6b212f/TwitchLib.EventSub.Websockets/Handler/Channel/ChatMessageHandler.cs) which is still in the Channel Namespace though.