### PR TITLE
rewrite ProcessDataAsync, replace DataReceivedArgs.Message(string) with DataReceivedArgs.Bytes(bytes[])

### DIFF
--- a/TwitchLib.EventSub.Websockets/Core/EventArgs/DataReceivedArgs.cs
+++ b/TwitchLib.EventSub.Websockets/Core/EventArgs/DataReceivedArgs.cs
@@ -1,7 +1,6 @@
-﻿namespace TwitchLib.EventSub.Websockets.Core.EventArgs
+﻿namespace TwitchLib.EventSub.Websockets.Core.EventArgs;
+
+internal class DataReceivedArgs : System.EventArgs
 {
-    internal class DataReceivedArgs : System.EventArgs
-    {
-        public string Message { get; internal set; }
-    }
+    public byte[] Bytes { get; internal set; }
 }

--- a/TwitchLib.EventSub.Websockets/Extensions/LogExtensions.cs
+++ b/TwitchLib.EventSub.Websockets/Extensions/LogExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.WebSockets;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using TwitchLib.EventSub.Websockets.Client;
 
@@ -7,10 +8,12 @@ namespace TwitchLib.EventSub.Websockets.Extensions
 {
     internal static partial class LogExtensions
     {
+        const LogLevel LogMessageLogLevel = LogLevel.Debug;
+
         [LoggerMessage(LogLevel.Error, "Exeption was throw when raising '{eventName}' event.")]
         public static partial void LogRaiseEventExeption(this ILogger<EventSubWebsocketClient> logger, string eventName, Exception ex);
 
-        [LoggerMessage(LogLevel.Debug, "{message}")]
+        [LoggerMessage(LogMessageLogLevel, "{message}")]
         public static partial void LogMessage(this ILogger<EventSubWebsocketClient> logger, string message);
 
         [LoggerMessage(LogLevel.Critical, "Websocket {sessionId} disconnected at {disconnectedAt}. Reason: {disconnectReason}")]
@@ -27,5 +30,13 @@ namespace TwitchLib.EventSub.Websockets.Extensions
         
         [LoggerMessage(LogLevel.Critical, "{closeStatus} - {closeStatusDescription}")]
         public static partial void LogWebsocketClosed(this ILogger<WebsocketClient> logger, WebSocketCloseStatus closeStatus, string closeStatusDescription);
+
+        public static void LogMessage(this ILogger<EventSubWebsocketClient> logger, byte[] message)
+        {
+            if (logger.IsEnabled(LogMessageLogLevel))
+            {
+                __LogMessageCallback(logger, Encoding.UTF8.GetString(message), null);
+            }
+        }
     }
 }


### PR DESCRIPTION
rewrite `ProcessDataAsync` so that there is only one method
`DataReceivedArgs` now returns `byte[] Bytes` instead of `string Message` - returning a string instead of bytes is extra work, because JsonSerializer converts the string back to bytes before deserializing it

todo: rewrite INotificationHandler to accept byte[] (or delete it as it just adds unnecessary work)